### PR TITLE
⬇️ Revert "⬆️ Bump eslint from 7.32.0 to 8.6.0 in /web-react-REST/web"

### DIFF
--- a/web-react-REST/web/package.json
+++ b/web-react-REST/web/package.json
@@ -17,7 +17,7 @@
     "@typescript-eslint/eslint-plugin": "^5.8.0",
     "@typescript-eslint/typescript-estree": "^5.6.0",
     "antd": "^4.17.4",
-    "eslint": "^8.6.0",
+    "eslint": "^7.11.0",
     "eslint-config-airbnb": "^19.0.2",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.3",


### PR DESCRIPTION
Reverts jmg7173/boiler-plates-and-examples#19 due to react script dependency.